### PR TITLE
add remove comments

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -52,6 +52,7 @@ class RunCommand extends Command
         // we will add a php close tag so the file can start with an open tag
         $code = '?>';
         $code .= file_get_contents($this->getTinkerFile());
+        $code = $this->removeComments($code);
 
         $this->shell->addInput($code);
 
@@ -101,6 +102,25 @@ class RunCommand extends Command
         }
 
         return $file;
+    }
+
+    public function removeComments(string $code): string
+    {
+        $tokens = collect(token_get_all($code));
+
+        return $tokens->reduce(function ($carry, $token) {
+            if (is_string($token)) {
+                return $carry . $token;
+            }
+
+            [$id, $text] = $token;
+
+            if ($id === T_COMMENT || $id === T_DOC_COMMENT) {
+                $text = '';
+            }
+
+            return $carry . $text;
+        }, '');
     }
 
     protected function cleanOutput(string $output): string


### PR DESCRIPTION
If last statement has a semicolon and there are comments afterwards the statement won't be shown in the console.

We need to remove `T_COMMENT` and `T_DOC_COMMENT` from end of code from file.

This PR adds a method to remove all comments from the code.